### PR TITLE
Only map valid locations

### DIFF
--- a/evohome/evohome.js
+++ b/evohome/evohome.js
@@ -121,22 +121,24 @@ Session.prototype.getSystemModeStatus = function(locationId) {
 Session.prototype.getLocations = function() {
     var url = "https://tccna.honeywell.com/WebAPI/emea/api/v1/location/installationInfo?userId=" + this.userInfo.userID + "&includeTemperatureControlSystems=True";
     return this._request(url).then(function(json) {
-        return _.map(json, function(location) {
-            var data = {}
-            data.locationID = location.locationInfo.locationId;
-            data.name = location.locationInfo.name;
-            data.streetAddress = location.locationInfo.streetAddress;
-            data.city = location.locationInfo.city;
-            data.country = location.locationInfo.country;
-            data.postcode = location.locationInfo.postcode;
-            data.locationType = location.locationInfo.locationType;
-            data.daylightSavingTimeEnabled = location.locationInfo.useDaylightSaveSwitching;
-            data.timeZone = location.locationInfo.timeZone;
-            data.devices = location.gateways[0].temperatureControlSystems[0].zones;
-            data.systemId = location.gateways[0].temperatureControlSystems[0].systemId;
+        return _(json).filter(function(x){
+                return x && x.locationInfo;
+            }).map(function(location) {
+                var data = {}
+                data.locationID = location.locationInfo.locationId;
+                data.name = location.locationInfo.name;
+                data.streetAddress = location.locationInfo.streetAddress;
+                data.city = location.locationInfo.city;
+                data.country = location.locationInfo.country;
+                data.postcode = location.locationInfo.postcode;
+                data.locationType = location.locationInfo.locationType;
+                data.daylightSavingTimeEnabled = location.locationInfo.useDaylightSaveSwitching;
+                data.timeZone = location.locationInfo.timeZone;
+                data.devices = location.gateways[0].temperatureControlSystems[0].zones;
+                data.systemId = location.gateways[0].temperatureControlSystems[0].systemId;
 
-            return new Location(data);
-        });
+                return new Location(data);
+            }).value();
     });
 }
 


### PR DESCRIPTION
This is a fix for issue #1.

I found that in my case getLocations returns a location with no data for locationInfo trying to read the locationId property throws an exception that can't be handled in Node-RED.

I changed the code a bit to not map a locations without locationInfo. In that case getLocations returns an empty array, this in turn will trigger the creation of a new session in evohome-status.js.